### PR TITLE
Throw an exception if tableIndexPathForSection: is invalid

### DIFF
--- a/ATV/ATVTableView.h
+++ b/ATV/ATVTableView.h
@@ -28,8 +28,11 @@
 #pragma mark - Private
 
 - (UITableViewCell*) cellForRowAtIndex:(NSUInteger)index inSection:(ATVTableSection*)section;
-// Return the index path in the table for the index path in the given section object.
+// Return the index path in the table for the index path in the given section object. Raises an exception if the
+// section is nil or not in the table view if mustExist is true (the default.)
 - (NSIndexPath*) tableIndexPathForSection:(ATVTableSection*)section index:(NSUInteger)index;
+// Use this version if you plan to handle nil.
+- (NSIndexPath*) tableIndexPathForSection:(ATVTableSection*)section index:(NSUInteger)index mustExist:(BOOL)mustExist;
 
 - (void) insertRowsAtIndices:(NSIndexSet*)indices
                    inSection:(ATVTableSection*)section


### PR DESCRIPTION
Formerly, we used an NSAssert to check that the section was in the table. Since asserts are generally disabled for release builds, this meant that this method would return a bogus value (NSNotFound, or MAXINT) if the section wasn't found, leading to a weird crash.

This changes the API so that it will raise an NSInternalConsistencyException if the section is not a member of the table view, and will crash with a clearer error. If you plan to check for the possibility of a `nil` return, you can use the new form, tableIndexPathForSection:index:mustExist with mustExist set to NO.